### PR TITLE
Clarify usage of `WorkerPlugin` in `webpack.config.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ npm install -D worker-plugin
 Then drop it into your **webpack.config.js:**
 
 ```diff
-plugins: [
-+    new WorkerPlugin()
-]
++ const WorkerPlugin = require('worker-plugin');
+
+module.exports = {
+  <...>
+  plugins: [
+  +    new WorkerPlugin()
+  ]
+  <...>
+}
 ```
 
 ## Usage


### PR DESCRIPTION
I followed the instructions in the README and encountered the following error:

```js
ReferenceError: WorkerPlugin is not defined
```

I am not familiar with WebPack, so I basically copy-pasted from https://webpack.js.org/ and your documentation. However, it seems like adding the following at the top of `webpack.config.js` resolves this issue:

```js
const WorkerPlugin = require('worker-plugin');
```

This updates the README to make this more clear.