### PR TITLE
Use prepack rather than prepublishOnly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 package-lock.json
 yarn.lock
+worker-plugin-*.tgz

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "GoogleChromeLabs/worker-plugin",
   "scripts": {
     "build": "microbundle --inline none --format cjs --no-compress src/*.js",
-    "prepublishOnly": "npm run build",
+    "prepack": "npm run build",
     "dev": "jest --verbose --watchAll",
     "test": "npm run build && jest --verbose",
     "release": "npm t && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"


### PR DESCRIPTION
Per https://docs.npmjs.com/misc/scripts this now allows this package to
also be installable as a git dependency.

I actually wanted to depend on the local branch in #5 but found out that after `npm install`ing this package, it was not correctly building. Using the other lifecycle callback allows this package to be installable as git dependency :tada: 