### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To configure the value of `output.globalObject` for WorkerPlugin's internal Webp
 ```js
 new WorkerPlugin({
   // use "self" as the global object when receiving hot updates.
-  globalObject: 'self' // <-- this is the default value
+  globalObject: 'self' // <-- The default value is 'window'.
 })
 ```
 


### PR DESCRIPTION
When there's no any configuration in `new WorkerPlugin()`, there would be such a warning message:
```
Warning (worker-plugin): output.globalObject is set to "window". It must be set to "self" to support HMR in Workers.
```
So It seems the default value is `window`, and it's incorrect in the `README.md` reads that the default value is `self`.