### PR TITLE
fix: replace `type` property with `undefined` except of replacing with empty string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,11 @@ export default class WorkerPlugin {
             if (this.options.workerType) {
               ParserHelpers.toConstantDependency(parser, JSON.stringify(this.options.workerType))(typeModuleExpr.value);
             } else if (this.options.preserveTypeModule !== true) {
-              ParserHelpers.toConstantDependency(parser, '')(typeModuleExpr);
+              // Options object can contain comma at the end e.g. `{ type: 'module', }`.
+              // Previously, `type` property was replaced with an empty string
+              // that left this comma.
+              // Currently the `type` property value is replaced with `undefined`.
+              ParserHelpers.toConstantDependency(parser, 'type:undefined')(typeModuleExpr);
             }
 
             return ParserHelpers.addParsedVariableToModule(parser, id, req);

--- a/test/fixtures/basic/entry.js
+++ b/test/fixtures/basic/entry.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-const worker = new Worker('./worker', { type: 'module' });
+const worker = new Worker('./worker', { type: 'module', });
 worker.onmessage = ({ data }) => {
   console.log('page got data: ', data);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,7 +44,17 @@ describe('worker-plugin', () => {
     expect(main).toMatch(/[^\n]*new\s+Worker\s*\([^)]*\)[^\n]*/g);
 
     const workerInit = main.match(/[^\n]*new\s+Worker\s*\([^)]*\)[^\n]*/g)[0];
-    expect(workerInit).toMatch(/new\s+Worker\s*\(\s*__webpack__worker__\d\s*(,\s*\{\}\s*)?\)/g);
+    // As it replaces the value of the `type` property with `undefined`
+    // it will emit a string that contains line breaks, like:
+    // `{\n type: void 0 \n}`.
+    // We have to replace those line breaks thus it will become
+    // one-line string, like:
+    // `const worker = new Worker(__webpack__worker__0, { type: void 0 });`
+    const workerInitWithoutLineBreak = workerInit.replace(/\n/g, '');
+    // Match also the `type: void 0` string
+    expect(workerInitWithoutLineBreak).toMatch(
+      /new\s+Worker\s*\(\s*__webpack__worker__\d\s*(,\s*\{\s+type\:\svoid [0]\s+\}\s*)?\)/g
+    );
 
     expect(main).toMatch(/module.exports = __webpack_require__\.p\s*\+\s*"0\.worker\.js"/g);
   });


### PR DESCRIPTION
Closes #25, #39 

I'm facing the same issue in the Angular application as we're using Prettier in our project that automatically adds those commas.

This is a tiny change that doesn't introduce any breaking changes. I was trying to find some documentation for Webpack's parser helpers but wasn't able to.

@developit ping.

---

Previously, tests were failing if I added comma at the end:

<img width="952" alt="Снимок экрана 2019-12-25 в 00 10 22" src="https://user-images.githubusercontent.com/7337691/71425910-23cb2380-26ab-11ea-8873-8c342746b2f1.png">
