### PR TITLE
Move SharedWorker under a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ module.exports = {
 }
 ```
 
+### `sharedWorker` _(boolean)_
+
+If set to `true`, this option enables the bundling of [SharedWorker](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker):
+
+```js
+const shared = new SharedWorker('./my-shared-worker.js', { type: 'module' });
+```
+
 ### `preserveTypeModule` _(boolean)_
 ### `workerType` _(string)_
 

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ export default class WorkerPlugin {
           };
           
           parser.hooks.new.for('Worker').tap(NAME, handleWorker('Worker'));
-          if (this.options.sharedWorker !== false) {
+          if (this.options.sharedWorker) {
             parser.hooks.new.for('SharedWorker').tap(NAME, handleWorker('SharedWorker'));
           }
         });

--- a/src/index.js
+++ b/src/index.js
@@ -84,8 +84,11 @@ export default class WorkerPlugin {
 
             return ParserHelpers.addParsedVariableToModule(parser, id, req);
           };
+          
           parser.hooks.new.for('Worker').tap(NAME, handleWorker('Worker'));
-          parser.hooks.new.for('SharedWorker').tap(NAME, handleWorker('SharedWorker'));
+          if (this.options.sharedWorker !== false) {
+            parser.hooks.new.for('SharedWorker').tap(NAME, handleWorker('SharedWorker'));
+          }
         });
       }
     });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -38,11 +38,14 @@ describe('Integration', () => {
 
     await server.stop();
   });
-  test('The SharedWorker is instantiated correctly', async () => {
+
+  test('SharedWorker is instantiated correctly', async () => {
     const fixture = 'shared';
 
     await runWebpack(fixture, {
-      plugins: [new WorkerPlugin()]
+      plugins: [new WorkerPlugin({
+        sharedWorker: true
+      })]
     });
 
     const server = await createStaticServer(path.resolve(__dirname, 'fixtures', fixture));


### PR DESCRIPTION
This means it can be released as a minor version change.