### PR TITLE
Move bundling of Worker under a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ If set to `true`, this option enables the bundling of [SharedWorker](https://dev
 const shared = new SharedWorker('./my-shared-worker.js', { type: 'module' });
 ```
 
+### `worker` _(boolean)_
+
+If set to `false`, this option disables the bundling of [Worker]. Intended to be used with `{ sharedWorker: true }` to allow bundling of [SharedWorker] only without also bundling [Worker].
+
 ### `preserveTypeModule` _(boolean)_
 ### `workerType` _(string)_
 

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,9 @@ export default class WorkerPlugin {
             return ParserHelpers.addParsedVariableToModule(parser, id, req);
           };
           
-          parser.hooks.new.for('Worker').tap(NAME, handleWorker('Worker'));
+          if (this.options.worker === undefined || this.options.worker) {
+            parser.hooks.new.for('Worker').tap(NAME, handleWorker('Worker'));
+          }
           if (this.options.sharedWorker) {
             parser.hooks.new.for('SharedWorker').tap(NAME, handleWorker('SharedWorker'));
           }

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ export default class WorkerPlugin {
             return ParserHelpers.addParsedVariableToModule(parser, id, req);
           };
           
-          if (this.options.worker === undefined || this.options.worker) {
+          if (this.options.worker !== false) {
             parser.hooks.new.for('Worker').tap(NAME, handleWorker('Worker'));
           }
           if (this.options.sharedWorker) {


### PR DESCRIPTION
Add support for turning off bundling of `Worker`, for situations where we only need to bundle `SharedWorker`.

Basically, it allows projects that want to use `SharedWorker` (and don't need `Worker`) to use this plugin without facing issues such as https://github.com/GoogleChromeLabs/worker-plugin/issues/12