### PR TITLE
Change worker chunk name from <ID> to w<ID>

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export default class WorkerPlugin {
               return false;
             }
 
-            const loaderOptions = { name: opts.name || workerId + '' };
+            const loaderOptions = { name: opts.name || 'w' + workerId };
             const req = `require(${JSON.stringify(workerLoader + '?' + JSON.stringify(loaderOptions) + '!' + dep.string)})`;
             const id = `__webpack__worker__${workerId++}`;
             ParserHelpers.toConstantDependency(parser, id)(expr.arguments[0]);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,7 +38,7 @@ describe('worker-plugin', () => {
 
     const assetNames = Object.keys(stats.assets);
     expect(assetNames).toHaveLength(2);
-    expect(assetNames).toContainEqual('0.worker.js');
+    expect(assetNames).toContainEqual('w0.worker.js');
 
     const main = stats.assets['main.js'];
     expect(main).toMatch(/[^\n]*new\s+Worker\s*\([^)]*\)[^\n]*/g);
@@ -56,7 +56,7 @@ describe('worker-plugin', () => {
       /new\s+Worker\s*\(\s*__webpack__worker__\d\s*(,\s*\{\s+type\:\svoid [0]\s+\}\s*)?\)/g
     );
 
-    expect(main).toMatch(/module.exports = __webpack_require__\.p\s*\+\s*"0\.worker\.js"/g);
+    expect(main).toMatch(/module.exports = __webpack_require__\.p\s*\+\s*"w0\.worker\.js"/g);
   });
 
   test('it replaces multiple Worker exports with __webpack_require__', async () => {
@@ -68,12 +68,12 @@ describe('worker-plugin', () => {
 
     const assetNames = Object.keys(stats.assets);
     expect(assetNames).toHaveLength(3);
-    expect(assetNames).toContainEqual('0.worker.js');
-    expect(assetNames).toContainEqual('1.worker.js');
+    expect(assetNames).toContainEqual('w0.worker.js');
+    expect(assetNames).toContainEqual('w1.worker.js');
 
     const main = stats.assets['main.js'];
-    expect(main).toMatch(/module.exports = __webpack_require__\.p\s*\+\s*"0\.worker\.js"/g);
-    expect(main).toMatch(/module.exports = __webpack_require__\.p\s*\+\s*"1\.worker\.js"/g);
+    expect(main).toMatch(/module.exports = __webpack_require__\.p\s*\+\s*"w0\.worker\.js"/g);
+    expect(main).toMatch(/module.exports = __webpack_require__\.p\s*\+\s*"w1\.worker\.js"/g);
   });
 
   test('retainModule:true leaves {type:module} in worker init', async () => {
@@ -248,8 +248,8 @@ describe('worker-plugin', () => {
           await sleep(1000);
           stats = await ready;
           await sleep(1000);
-          expect(Object.keys(stats.assets).sort()).toEqual(['0.worker.js', 'main.js']);
-          expect(stats.assets['0.worker.js']).toContain(`hello from worker ${i}`);
+          expect(Object.keys(stats.assets).sort()).toEqual(['main.js', 'w0.worker.js']);
+          expect(stats.assets['w0.worker.js']).toContain(`hello from worker ${i}`);
         }
       } finally {
         watcher.close();


### PR DESCRIPTION
Fixes #43, as it avoids conflicts with other number-based webpack
chunks.
Note that the conflict may not be on the filename (since this plugin
adds '.worker' to it) but on the internal key used by webpack in
referencing modules.

E.g. in the below generated webpack loader code, using `w0` avoids conflict with chunkId `0` that would otherwise never load. 

![image](https://user-images.githubusercontent.com/604263/76267393-dfdbc980-626a-11ea-8b93-543188369ebc.png)

I'd argue that a cleaner "fix" would be to name the chunk with something like `worker.${id}` and drop the _chunkFilename_ replacement logic (that inserts `.worker.` before the output extension), but that'd break the naming of those who provided a name to the worker, so you tell me.