### PR TITLE
Strict ESM Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/worker-plugin.js",
   "repository": "GoogleChromeLabs/worker-plugin",
   "scripts": {
-    "build": "microbundle --inline none --format cjs --no-compress src/*.js",
+    "build": "microbundle --raw --inline none --format cjs --no-compress src/*.js",
     "prepack": "npm run build",
     "dev": "jest --verbose --watchAll",
     "test": "npm run build && jest --verbose",

--- a/src/index.js
+++ b/src/index.js
@@ -15,11 +15,14 @@
  */
 
 import path from 'path';
-import ParserHelpers from 'webpack/lib/ParserHelpers';
 import WORKER_PLUGIN_SYMBOL from './symbol';
+import ParserHelpers from 'webpack/lib/ParserHelpers';
+let HarmonyImportSpecifierDependency;
+try {
+  HarmonyImportSpecifierDependency = require('webpack/lib/dependencies/HarmonyImportSpecifierDependency');
+} catch (e) {}
 
 const NAME = 'WorkerPlugin';
-const JS_TYPES = ['auto', 'esm', 'dynamic'];
 const workerLoader = path.resolve(__dirname, 'loader.js');
 
 export default class WorkerPlugin {
@@ -31,66 +34,107 @@ export default class WorkerPlugin {
   apply (compiler) {
     compiler.hooks.normalModuleFactory.tap(NAME, factory => {
       let workerId = 0;
-      for (const type of JS_TYPES) {
-        factory.hooks.parser.for(`javascript/${type}`).tap(NAME, parser => {
-          const handleWorker = workerTypeString => expr => {
-            const dep = parser.evaluateExpression(expr.arguments[0]);
+      factory.hooks.parser.for('javascript/auto').tap(NAME, parser => parse(parser, false));
+      factory.hooks.parser.for('javascript/dynamic').tap(NAME, parser => parse(parser, false));
+      factory.hooks.parser.for('javascript/esm').tap(NAME, parser => parse(parser, true));
 
-            if (!dep.isString()) {
-              parser.state.module.warnings.push({
-                message: `new ${workerTypeString}() will only be bundled if passed a String.`
-              });
-              return false;
-            }
+      const parse = (parser, esModule) => {
+        const handleWorker = workerTypeString => expr => {
+          const dep = parser.evaluateExpression(expr.arguments[0]);
 
-            const optsExpr = expr.arguments[1];
-            let typeModuleExpr;
-            let opts;
-            if (optsExpr) {
-              opts = {};
-              for (let i = optsExpr.properties.length; i--;) {
-                const prop = optsExpr.properties[i];
-                if (prop.type === 'Property' && !prop.computed && !prop.shorthand && !prop.method) {
-                  opts[prop.key.name] = parser.evaluateExpression(prop.value).string;
+          if (!dep.isString()) {
+            parser.state.module.warnings.push({
+              message: `new ${workerTypeString}() will only be bundled if passed a String.`
+            });
+            return false;
+          }
 
-                  if (prop.key.name === 'type') {
-                    typeModuleExpr = prop;
-                  }
+          const optsExpr = expr.arguments[1];
+          let hasInitOptions = false;
+          let typeModuleExpr;
+          let opts;
+          if (optsExpr) {
+            opts = {};
+            for (let i = optsExpr.properties.length; i--;) {
+              const prop = optsExpr.properties[i];
+              if (prop.type === 'Property' && !prop.computed && !prop.shorthand && !prop.method) {
+                opts[prop.key.name] = parser.evaluateExpression(prop.value).string;
+
+                if (prop.key.name === 'type') {
+                  typeModuleExpr = prop;
+                } else {
+                  hasInitOptions = true;
                 }
               }
             }
-
-            if (!opts || opts.type !== 'module') {
-              parser.state.module.warnings.push({
-                message: `new ${workerTypeString}() will only be bundled if passed options that include { type: 'module' }.${opts ? `\n  Received: new ${workerTypeString}()(${JSON.stringify(dep.string)}, ${JSON.stringify(opts)})` : ''}`
-              });
-              return false;
-            }
-
-            const loaderOptions = { name: opts.name || workerId + '' };
-            const req = `require(${JSON.stringify(workerLoader + '?' + JSON.stringify(loaderOptions) + '!' + dep.string)})`;
-            const id = `__webpack__worker__${workerId++}`;
-            ParserHelpers.toConstantDependency(parser, id)(expr.arguments[0]);
-
-            if (this.options.workerType) {
-              ParserHelpers.toConstantDependency(parser, JSON.stringify(this.options.workerType))(typeModuleExpr.value);
-            } else if (this.options.preserveTypeModule !== true) {
-              // Options object can contain comma at the end e.g. `{ type: 'module', }`.
-              // Previously, `type` property was replaced with an empty string
-              // that left this comma.
-              // Currently the `type` property value is replaced with `undefined`.
-              ParserHelpers.toConstantDependency(parser, 'type:undefined')(typeModuleExpr);
-            }
-
-            return ParserHelpers.addParsedVariableToModule(parser, id, req);
-          };
-          
-          parser.hooks.new.for('Worker').tap(NAME, handleWorker('Worker'));
-          if (this.options.sharedWorker) {
-            parser.hooks.new.for('SharedWorker').tap(NAME, handleWorker('SharedWorker'));
           }
-        });
-      }
+
+          if (!opts || opts.type !== 'module') {
+            parser.state.module.warnings.push({
+              message: `new ${workerTypeString}() will only be bundled if passed options that include { type: 'module' }.${opts ? `\n  Received: new ${workerTypeString}()(${JSON.stringify(dep.string)}, ${JSON.stringify(opts)})` : ''}`
+            });
+            return false;
+          }
+
+          const isStrictModule = esModule || (parser.state.buildMeta && parser.state.buildMeta.strictHarmonyModule);
+
+          // Querystring-encoded loader prefix (faster/cleaner than JSON parameters):
+          const loaderRequest = `${workerLoader}?name=${encodeURIComponent(opts.name || workerId)}${isStrictModule ? '&esModule' : ''}!${dep.string}`;
+
+          // Unique ID for the worker URL variable:
+          const id = `__webpack__worker__${workerId++}`;
+
+          // .mjs / strict harmony mode
+          if (isStrictModule) {
+            const module = parser.state.current;
+
+            if (!HarmonyImportSpecifierDependency) {
+              throw Error(`${NAME}: Failed to import HarmonyImportSpecifierDependency. This plugin requires Webpack version 4.`);
+            }
+
+            // This is essentially the internals of "prepend an import to the module":
+            const dependency = new HarmonyImportSpecifierDependency(
+              loaderRequest,
+              module,
+              workerId, // no idea if this actually needs to be unique. 0 seemed to work. safety first?
+              parser.scope,
+              'default',
+              id, // this never gets used
+              expr.arguments[0].range, // replace the usage/callsite with the generated reference: X_IMPORT_0["default"]
+              true
+            );
+            // avoid serializing the full loader filepath: (this gets prepended to unique suffix)
+            dependency.userRequest = dep.string;
+
+            module.addDependency(dependency);
+          } else {
+            // For CommonJS/Auto
+            const req = `require(${JSON.stringify(loaderRequest)})`;
+            ParserHelpers.toConstantDependency(parser, id)(expr.arguments[0]);
+            ParserHelpers.addParsedVariableToModule(parser, id, req);
+          }
+
+          // update/remove the WorkerInitOptions argument
+          if (this.options.workerType) {
+            ParserHelpers.toConstantDependency(parser, JSON.stringify(this.options.workerType))(typeModuleExpr.value);
+          } else if (this.options.preserveTypeModule !== true) {
+            if (hasInitOptions) {
+              // there might be other options - to avoid trailing comma issues, replace the type value with undefined but *leave the key*:
+              ParserHelpers.toConstantDependency(parser, 'type:undefined')(typeModuleExpr);
+            } else {
+              // there was only a `{type}` option, so we can remove the whole second argument:
+              ParserHelpers.toConstantDependency(parser, '')(optsExpr);
+            }
+          }
+
+          return true;
+        };
+
+        parser.hooks.new.for('Worker').tap(NAME, handleWorker('Worker'));
+        if (this.options.sharedWorker) {
+          parser.hooks.new.for('SharedWorker').tap(NAME, handleWorker('SharedWorker'));
+        }
+      };
     });
   }
 }

--- a/test/_page.js
+++ b/test/_page.js
@@ -1,6 +1,6 @@
 import puppeteer from 'puppeteer';
 
-export async function evaluatePage (url, matches, timeout = 4000) {
+export async function evaluatePage (url, matches, timeout = 10000) {
   const args = await puppeteer.defaultArgs();
   const browser = await puppeteer.launch({
     args: [

--- a/test/_util.js
+++ b/test/_util.js
@@ -23,12 +23,12 @@ export function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export function runWebpack (fixture, { output, plugins, ...config } = {}) {
+export function runWebpack (fixture, { output, plugins, terserOptions, ...config } = {}) {
   return run(callback => webpack({
     mode: 'production',
     devtool: false,
     context: path.resolve(__dirname, 'fixtures', fixture),
-    entry: './entry.js',
+    entry: './entry',
     output: {
       publicPath: 'dist/',
       path: path.resolve(__dirname, 'fixtures', fixture, 'dist'),
@@ -37,7 +37,7 @@ export function runWebpack (fixture, { output, plugins, ...config } = {}) {
     optimization: {
       minimizer: [
         new TerserPlugin({
-          terserOptions: {
+          terserOptions: terserOptions || {
             mangle: false,
             output: {
               beautify: true
@@ -56,7 +56,7 @@ export function runWebpack (fixture, { output, plugins, ...config } = {}) {
   }, callback));
 }
 
-export function watchWebpack (fixture, { output, plugins, context, ...config } = {}) {
+export function watchWebpack (fixture, { output, plugins, context, terserOptions, ...config } = {}) {
   context = context || path.resolve(__dirname, 'fixtures', fixture);
   const compiler = webpack({
     mode: 'production',
@@ -71,7 +71,7 @@ export function watchWebpack (fixture, { output, plugins, context, ...config } =
       minimize: true,
       minimizer: [
         new TerserPlugin({
-          terserOptions: {
+          terserOptions: terserOptions || {
             mangle: false,
             output: {
               beautify: true

--- a/test/fixtures/strict/entry.mjs
+++ b/test/fixtures/strict/entry.mjs
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+const worker = new Worker('./worker', { type: 'module' });
+worker.onmessage = ({ data }) => {
+  console.log('page got data: ', data);
+};

--- a/test/fixtures/strict/index.html
+++ b/test/fixtures/strict/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html><body>
+  <!--
+ Copyright 2018 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+  -->
+  <script src="dist/main.js"></script>
+</body></html>

--- a/test/fixtures/strict/worker.mjs
+++ b/test/fixtures/strict/worker.mjs
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+console.log('loaded worker');
+postMessage('hello');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -181,7 +181,59 @@ describe('worker-plugin', () => {
 
     expect(stats.assets['main.js']).toMatch(/new\s+Worker\s*\(\s*new\s+Blob\s*\(\s*\[\s*'onmessage=\(\)=>\{postMessage\("right back at ya"\)\}'\s*\]\s*\)\s*\)/g);
   });
-  
+
+  describe('ESM strict mode', () => {
+    test('it should work in strict ESM mode', async () => {
+      const stats = await runWebpack('strict', {
+        plugins: [
+          new WorkerPlugin()
+        ],
+        mode: 'development'
+      });
+
+      const assetNames = Object.keys(stats.assets);
+      expect(assetNames).toHaveLength(2);
+      expect(assetNames).toContainEqual('0.worker.js');
+
+      const main = stats.assets['main.js'];
+      expect(main).toMatch(/[^\n]*new Worker\s*\([^)]*\)[^\n]*/g);
+
+      const log = main.match(/new Worker\s*\(([^)]*)\)[^\n]*/)[1];
+      expect(log).toMatch(/_worker__WEBPACK_IMPORTED_MODULE_\d__\["default"\]/gi);
+
+      // should also put the loader into ESM mode:
+      expect(main).toMatch(/__webpack_exports__\["default"\]\s*=\s*\(?\s*__webpack_require__\.p\s*\+\s*"0\.worker\.js"\)?;?/g);
+      // the output (in dev mode) looks like this:
+      //   /* harmony default export */ __webpack_exports__[\"default\"] = (__webpack_require__.p + \"0.worker.js\");
+    });
+
+    test('it should inline for production', async () => {
+      const stats = await runWebpack('strict', {
+        plugins: [
+          new WorkerPlugin()
+        ],
+        terserOptions: {
+          compress: {
+            pure_getters: true
+          }
+        }
+      });
+
+      const assetNames = Object.keys(stats.assets);
+      expect(assetNames).toHaveLength(2);
+      expect(assetNames).toContainEqual('0.worker.js');
+
+      const main = stats.assets['main.js'];
+      expect(main).toMatch(/[^\n]*new Worker\s*\([^)]*\)[^\n]*/g);
+
+      const log = main.match(/new Worker\s*\(([^)]*)\)[^\n]*/)[1];
+      expect(log).toMatch(/^[a-z0-9$_]+\.p\s*\+\s*(['"])0\.worker\.js\1/gi);
+
+      // shouldn't be any trace of the intermediary url provider module left
+      expect(main).not.toMatch(/export default/g);
+    });
+  });
+
   describe('worker-plugin/loader', () => {
     test('it returns a URL when applied to an import', async () => {
       const stats = await runWebpack('loader', {


### PR DESCRIPTION
This fixes an issue where constructing Workers in Webpack's strict mode (`javascript/esm`) would throw an exception during bundling due to the generated require() statement.

Fixing this required reaching into Webpack internals, and I couldn't find any better way to do it. On the plus side, the output is much nicer and supports module concatenation (`new Worker(m.p+"0.worker.js")`).

Fixes #38 🎉