### PR TITLE
Support for SplitChunksPlugin

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -91,8 +91,9 @@ export function pitch (request) {
         // Sort to ensure the output is predictable.
         uniqueFiles.sort();
         const file = chunks.find(c => c.name === options.name).files[0];
-        compilation.assets[file] = new ConcatSource(uniqueFiles.map(chunk => `importScripts(${JSON.stringify(chunk)});`).join('\n'), compilation.assets[file]);
+        compilation.assets[file] = new ConcatSource(`importScripts(${uniqueFiles.map(chunk => `${JSON.stringify(chunk)}`).join(', ')});\n\n`, compilation.assets[file]);
       }
+
       callback();
     })
   });


### PR DESCRIPTION
Searched around and came across https://github.com/webpack/webpack/issues/6472, [worker-injector-generator-plugin](worker-injector-generator-plugin) and a [stackoverflow answer](https://stackoverflow.com/questions/3248384/document-createelementscript-synchronously)

This adds support for sharing chunks between workers / main entry points.

To use it, you can simply use `webpackConfig.splitChunks`. Note that you also need to define `webpackConfig.splitChunks.cacheGroups`