### PR TITLE
Document "dynamic" output.filename requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ module.exports = {
 }
 ```
 
+> **Note:** If you're planning on having more than one worker, you'll need to make sure [`output.filename`](https://webpack.js.org/configuration/output/#outputfilename) is set to something dynamic, e.g. `"[name].bundle.js"` otherwise the generated filenames will overwrite one another. 
+
 ## Usage
 
 **worker.js**: _(our worker module)_


### PR DESCRIPTION
A static value for `output.filename` in the Webpack config will cause issues when multiple workers are used. Webpack does warn about this by printing `WARNING in Conflict: Multiple assets emit different content to the same filename`, but it took some digging to discover why. 

Issue https://github.com/GoogleChromeLabs/worker-plugin/issues/24 discusses this problem, but I would have spent less time being confused if the "dynamic filename" requirement was mentioned in the documentation.  