### PR TITLE
fix: replace options parameter with `undefined` to fix trailing commas

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,8 +122,8 @@ export default class WorkerPlugin {
               // there might be other options - to avoid trailing comma issues, replace the type value with undefined but *leave the key*:
               ParserHelpers.toConstantDependency(parser, 'type:undefined')(typeModuleExpr);
             } else {
-              // there was only a `{type}` option, so we can remove the whole second argument:
-              ParserHelpers.toConstantDependency(parser, '')(optsExpr);
+              // there was only a `{type}` option, we replace the opts argument with undefined to avoid trailing comma issues:
+              ParserHelpers.toConstantDependency(parser, 'undefined')(optsExpr);
             }
           }
 

--- a/test/fixtures/no-trailing-comma/entry.js
+++ b/test/fixtures/no-trailing-comma/entry.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+const workerOne = new Worker('./worker', { type: 'module', });
+workerOne.onmessage = ({ data }) => {
+  console.log('page got data: ', data);
+};
+
+const workerTwo = new Worker('./worker', { type: 'module', name: 'foo' });
+workerTwo.onmessage = ({ data }) => {
+  console.log('page got data: ', data);
+};

--- a/test/fixtures/no-trailing-comma/index.html
+++ b/test/fixtures/no-trailing-comma/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html><body>
+  <!--
+ Copyright 2018 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+  -->
+  <script src="dist/main.js"></script>
+</body></html>

--- a/test/fixtures/no-trailing-comma/worker.js
+++ b/test/fixtures/no-trailing-comma/worker.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+console.log('hello from worker');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,20 +42,6 @@ describe('worker-plugin', () => {
 
     const main = stats.assets['main.js'];
     expect(main).toMatch(/[^\n]*new\s+Worker\s*\([^)]*\)[^\n]*/g);
-
-    const workerInit = main.match(/[^\n]*new\s+Worker\s*\([^)]*\)[^\n]*/g)[0];
-    // As it replaces the value of the `type` property with `undefined`
-    // it will emit a string that contains line breaks, like:
-    // `{\n type: void 0 \n}`.
-    // We have to replace those line breaks thus it will become
-    // one-line string, like:
-    // `const worker = new Worker(__webpack__worker__0, { type: void 0 });`
-    const workerInitWithoutLineBreak = workerInit.replace(/\n/g, '');
-    // Match also the `type: void 0` string
-    expect(workerInitWithoutLineBreak).toMatch(
-      /new\s+Worker\s*\(\s*__webpack__worker__\d\s*(,\s*\{\s+type\:\svoid [0]\s+\}\s*)?\)/g
-    );
-
     expect(main).toMatch(/module.exports = __webpack_require__\.p\s*\+\s*"0\.worker\.js"/g);
   });
 
@@ -232,6 +218,31 @@ describe('worker-plugin', () => {
       // shouldn't be any trace of the intermediary url provider module left
       expect(main).not.toMatch(/export default/g);
     });
+  });
+
+  test('should not emit trailing commas', async () => {
+    const stats = await runWebpack('no-trailing-comma', {
+      plugins: [
+        new WorkerPlugin()
+      ],
+    });
+
+    const assetNames = Object.keys(stats.assets);
+    expect(assetNames).toHaveLength(3);
+
+    // As it replaces the value of the `type` property with `undefined`
+    // it will emit a string that contains line breaks, like:
+    // `{\n type: void 0 \n}`.
+    // We have to replace those line breaks thus it will become one-line string, like:
+    const main = stats.assets['main.js'].replace(/\n/g, '');
+
+    // Verify that we replace the second parameter when it's `{ type: module }` with `undefined`
+    // and there are no trailing commas.
+    // Match `new Worker(__webpack__worker__0, { type: void 0 })`
+    expect(main).toMatch(/new Worker\s*\(__webpack__worker__\d, void 0\)/);
+
+    // Match `new Worker(__webpack__worker__0, { type: void 0, name: "foo" })`
+    expect(main).toMatch(/new Worker\s*\(__webpack__worker__\d, {\s*type\: void 0,\s*name\: "foo"\s*}\)/);
   });
 
   describe('worker-plugin/loader', () => {


### PR DESCRIPTION


Currently when the options parameter only contains `type` property the parameter is removed completely which results in a trailing comma. With this change we replace the options parameter with `undefined`.

Before
```
const hashcashWorker = new Worker(__webpack__worker__0, );
```

Now
```
const hashcashWorker = new Worker(__webpack__worker__0, void 0);
```

Fixes #65