### PR TITLE
Add additional require path for Webpack 5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,7 @@ import WORKER_PLUGIN_SYMBOL from './symbol';
 let ParserHelpers;
 try {
   ParserHelpers = require('webpack/lib/javascript/JavascriptParserHelpers'); // Webpack 5
-} catch (e) {
-  console.warn('Could not find Webpack 5 path', e);
-}
+} catch (e) {}
 ParserHelpers = ParserHelpers || require('webpack/lib/ParserHelpers'); // Webpack 4
 let HarmonyImportSpecifierDependency;
 try {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,13 @@
 
 import path from 'path';
 import WORKER_PLUGIN_SYMBOL from './symbol';
-import ParserHelpers from 'webpack/lib/ParserHelpers';
+let ParserHelpers;
+try {
+  ParserHelpers = require('webpack/lib/javascript/JavascriptParserHelpers'); // Webpack 5
+} catch (e) {
+  console.warn('Could not find Webpack 5 path', e);
+}
+ParserHelpers = ParserHelpers || require('webpack/lib/ParserHelpers'); // Webpack 4
 let HarmonyImportSpecifierDependency;
 try {
   HarmonyImportSpecifierDependency = require('webpack/lib/dependencies/HarmonyImportSpecifierDependency');


### PR DESCRIPTION
Webpack 5 changed the location of their `ParserHelpers`, once in https://github.com/webpack/webpack/pull/7640 and then in https://github.com/webpack/webpack/pull/9804. This should resolve so it is also compatible to the new path (as of `5.0.0-beta.16`) and resolve #68.

Please note that I didn't test the rest of the logic with Webpack 5, only updated the location to `ParserHelpers`.