### PR TITLE
Custom filename and chunkFilename support

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -40,8 +40,8 @@ export function pitch (request) {
   const options = loaderUtils.getOptions(this) || {};
   const chunkFilename = compilerOptions.output.chunkFilename.replace(/\.([a-z]+)$/i, '.worker.$1');
   const workerOptions = {
-    filename: chunkFilename.replace(/\[(?:chunkhash|contenthash)(:\d+(?::\d+)?)?\]/g, '[hash$1]'),
-    chunkFilename,
+    filename: (options.filename || pluginOptions.filename || chunkFilename).replace(/\[(?:chunkhash|contenthash)(:\d+(?::\d+)?)?\]/g, '[hash$1]'),
+    chunkFilename: options.chunkFilename || pluginOptions.chunkFilename || chunkFilename,
     globalObject: pluginOptions.globalObject || 'self'
   };
 

--- a/test/fixtures/code-splitting/dep.js
+++ b/test/fixtures/code-splitting/dep.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export const foo = 'bar';

--- a/test/fixtures/code-splitting/entry.js
+++ b/test/fixtures/code-splitting/entry.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+const worker = new Worker('./worker', { type: 'module' });
+worker.onmessage = ({ data }) => {
+  console.log('page got data: ', data);
+};
+worker.postMessage('hello');

--- a/test/fixtures/code-splitting/index.html
+++ b/test/fixtures/code-splitting/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html><body>
+  <!--
+ Copyright 2018 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+  -->
+  <script src="dist/main.js"></script>
+</body></html>

--- a/test/fixtures/code-splitting/worker.js
+++ b/test/fixtures/code-splitting/worker.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+console.log('hello from worker');
+
+addEventListener('message', ({ data }) => {
+  console.log('worker got message', data);
+  import('./dep').then(m => {
+    if (data === 'hello') {
+      postMessage(m.foo);
+    }
+  });
+});


### PR DESCRIPTION
This adds support for specifying custom templates for `filename` and `chunkFilename` when instantiating WorkerPlugin in `webpack.config.js`:

```js
new WorkerPlugin({
    filename: '[name].[hash:5].js',
    chunkFilename: '[name].[hash:5].js',
})
```

The config properties are also supported as loader parameters:

```js
import Worker from "worker-plugin/loader?filename=foo.[hash:5].js!./worker";
```

This fixes #76.