### PR TITLE
Fix `Module parse failed: Cannot read property 'length' of undefined`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ export default class WorkerPlugin {
           let hasInitOptions = false;
           let typeModuleExpr;
           let opts;
-          if (optsExpr) {
+          if (optsExpr && optsExpr.properties) {
             opts = {};
             for (let i = optsExpr.properties.length; i--;) {
               const prop = optsExpr.properties[i];


### PR DESCRIPTION
Fix for https://github.com/GoogleChromeLabs/worker-plugin/issues/93

Checks that optsExpr.properties is defined.